### PR TITLE
fix(rateLimiter): patch a possible memory leak in the rate limiter

### DIFF
--- a/src/routes/raccoons.ts
+++ b/src/routes/raccoons.ts
@@ -299,7 +299,7 @@ export const raccsController = new Elysia()
       const files = await fileService.listFiles("videos", ".mp4");
 
       if (files.length === 0) {
-        return { success: false, error: "No videos found" };
+        return respond(404, { success: false, error: "No videos found" });
       }
 
       const randomIndex = Math.floor(Math.random() * files.length);
@@ -307,7 +307,7 @@ export const raccsController = new Elysia()
       const fileBuffer = await fileService.getFile(selectedFile.path);
 
       if (!fileBuffer) {
-        return { success: false, error: "Video not found" };
+        return respond(404, { success: false, error: "Video not found" });
       }
 
       const filename = selectedFile.name;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,0 @@
-name = "api"
-compatibility_date = "2025-05-17"
-node_compat = true
-
-[[r2_buckets]]
-binding = "racclol"
-bucket_name = "racc-lol"


### PR DESCRIPTION
also removes the seemingly redundant wrangler.toml file since there's no use of R2 in the code and modify the response of `GET /video`  to be more consistent with the rest of the API